### PR TITLE
Workflow to bump major version

### DIFF
--- a/.github/workflows/major-version.yml
+++ b/.github/workflows/major-version.yml
@@ -1,0 +1,16 @@
+name: Tag Major
+on:
+  push: { tags: "v*.*.*" }
+  workflow_call:
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - env:
+          tag: ${{github.ref}}
+        run: |
+          tag=${tag#refs/tags/}
+          major=${tag%%.*}
+          git push -f origin "HEAD:refs/heads/$major"


### PR DESCRIPTION

# Type of PR (feature, enhancement, bug fix, etc.)

workflow enhancement

## Description

Keeps a 'vMajor' ref (branch) in sync with the latest tag for that major version. This way consumers can pin to the major version and receive minor/patch updates. 

modeled after: https://github.com/nodenv/.github/blob/main/.github/workflows/tag-major.yml

example runs: https://github.com/nodenv/.github/actions/workflows/tag-major.yml

## Why should this be added

Allow the action to be released by tagging (git tag) with full semver-style version. But at the same time still allow consumers to pin only to a major version.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] Actions are passing
