### PR TITLE
Fix standardrb/standard-ruby-action version in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: StandardRB Linter
-      uses: standardrb/standard-ruby-action@v0.1.0
+      uses: standardrb/standard-ruby-action@v0.0.5
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

Bug fix

## Description

I tried using the example workflow, and it fails with:

```
Unable to resolve action `standardrb/standard-ruby-action@v0.1.0`, unable to find version `v0.1.0`
```

It was using 0.1.0 which doesn't seem to exist. This changes it to 0.0.5, which works, but I'm not sure it is what should be in the docs.

Please include a summary of the change and which issue is fixed.

Fixes # (issue)

## Why should this be added

Easier to people to start using it.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] Actions are passing
