### PR TITLE
Update versions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Add the following to your GitHub action workflow to use StandardRB Linter Action
 
 ```yaml
 - name: StandardRB Linter
-  uses: standardrb/standard-ruby-action@v0.1.0
+  uses: standardrb/standard-ruby-action@v0.0.5
   env:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     USE_BUNDLE_VERSION: true # anything else (or omitting) will run the current version instead of your projects version
@@ -44,7 +44,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - name: StandardRB Linter
       uses: standardrb/standard-ruby-action@v0.0.5
       env:


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

Bug fix

## Description

The `README.md` file incorrectly says to use `v0.1.0` which isn't released.
The `actions/checkout` version is also 3 major versions outdated.

This is very similar to #10 which was already merged.

## Why should this be added

Stops this happening:

> Error: Unable to resolve action `standardrb/standard-ruby-action@v0.1.0`, unable to find version `v0.1.0`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Actions are passing
