### PR TITLE
Use Ruby from `.ruby-version` if it exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ permissions:
 
 ## Options
 
-* `ruby-version` - This will be forwarded to the [ruby/setup-ruby](https://github.com/ruby/setup-ruby) action, so it takes the same values.
-* `autofix` - If set to `false`, the action will not attempt to auto-fix any errors. Defaults to `true`.
+- `ruby-version` - If your project has a `.ruby-version` file, this Action will use that version of Ruby. If not, this will be forwarded to the [ruby/setup-ruby](https://github.com/ruby/setup-ruby) action, so it takes the same values.
+- `autofix` - If set to `false`, the action will not attempt to auto-fix any errors. Defaults to `true`.
 
 Example with options set:
 

--- a/action.yml
+++ b/action.yml
@@ -19,10 +19,22 @@ runs:
     - name: Checkout code
       uses: actions/checkout@v4
 
+    - name: Check for .ruby-version file
+      id: use_ruby_version_or_default
+      shell: bash
+      run: |
+        if [ -f .ruby-version ]; then
+          echo "Using Ruby version from .ruby-version file"
+          RUBY_VERSION=$(cat .ruby-version)
+          echo "ruby-version=$RUBY_VERSION" >> $GITHUB_ENV
+        else
+          echo "No .ruby-version file found, using default"
+        fi
+
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: ${{ inputs.ruby-version }}
+        ruby-version: ${{ env.ruby-version || inputs.ruby-version }}
         bundler-cache: true
 
     - name: Run Standard Ruby with autofix


### PR DESCRIPTION
Currently, we use the latest version of Ruby available to run this GitHub Action. To specify a particular Ruby version, one can make use of `with:` and set the `ruby-version:`. As a convention, Ruby projects allow the Ruby version to be set in a file at the root of the project called `.ruby-version`.

This commit updates this GitHub Action to read the Ruby version from `.ruby-version` if it exists. If not, it will fall back to the defaults.

Resolves #19

Ref:
- https://github.com/standardrb/standard-ruby-action?tab=readme-ov-file#options
- https://github.com/standardrb/standard-ruby-action/issues/19