### PR TITLE
Allow specifying a working directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ permissions:
 
 - `ruby-version` - If your project has a `.ruby-version` file, this Action will use that version of Ruby. If not, this will be forwarded to the [ruby/setup-ruby](https://github.com/ruby/setup-ruby) action, so it takes the same values.
 - `autofix` - If set to `false`, the action will not attempt to auto-fix any errors. Defaults to `true`.
-- `workdir` - If set the action will descend to this directory before running `bundle exec standardrb …`. Defaults to `.`.
+- `workdir` - If set the action will descend to this directory before running `bundle exec standardrb …` and other relevant setup commands. Defaults to `.`.
 
 Example with options set:
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ permissions:
 
 - `ruby-version` - If your project has a `.ruby-version` file, this Action will use that version of Ruby. If not, this will be forwarded to the [ruby/setup-ruby](https://github.com/ruby/setup-ruby) action, so it takes the same values.
 - `autofix` - If set to `false`, the action will not attempt to auto-fix any errors. Defaults to `true`.
+- `workdir` - If set the action will descend to this directory before running `bundle exec standardrb …`. Defaults to `.`.
 
 Example with options set:
 
@@ -62,6 +63,7 @@ Example with options set:
   with:
     ruby-version: '3.3'
     autofix: false
+    workdir: my/app/subdirectory
 ```
 
 ## Screenshots

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,9 @@ inputs:
     description: 'Whether autofixes should be committed back to the branch'
     required: false
     default: 'true'
+  workdir:
+    description: "The working directory from which to run this action's commands. Default '.'"
+    default: '.'
 
 runs:
   using: composite
@@ -22,6 +25,7 @@ runs:
     - name: Check for .ruby-version file
       id: use_ruby_version_or_default
       shell: bash
+      working-directory: ${{ inputs.workdir }}
       run: |
         if [ -f .ruby-version ]; then
           echo "Using Ruby version from .ruby-version file"
@@ -36,16 +40,19 @@ runs:
       with:
         ruby-version: ${{ env.ruby-version || inputs.ruby-version }}
         bundler-cache: true
+        working-directory: ${{ inputs.workdir }}
 
     - name: Run Standard Ruby with autofix
       id: standardrb
       shell: bash
+      working-directory: ${{ inputs.workdir }}
       run: bundle exec standardrb ${{ inputs.autofix == 'true' && '--fix' || '' }} --format github --format "Standard::Formatter"
       continue-on-error: true
 
     - name: Check for modified files
       id: check_changes
       shell: bash
+      working-directory: ${{ inputs.workdir }}
       run: |
         if [ -n "$(git diff --name-only --diff-filter=M)" ]; then
           echo "standardrb_autofixes_found=true" >> $GITHUB_ENV


### PR DESCRIPTION
Allow running standardrb and the commands to set it up in a subdirectory of a repo, allowing for use in monorepos and other weird repo layouts. Mimics the support for a working directory in [reviewdog/action-rubocop](https://github.com/reviewdog/action-rubocop).

Tested with [code in the root of an app](https://github.com/wjessop/testapp), and [with the code in a subdir](https://github.com/wjessop/testapp2) using the new functionality. See the action runs for those repos.

Fixes https://github.com/standardrb/standard-ruby-action/issues/21