### PR TITLE
Create Release GHA workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,35 @@
+name: Release
+on:
+  push: { tags: "v*.*.*" }
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  # Create a GitHub Release for each pushed git-tag
+  github:
+    permissions: { contents: write }
+    runs-on: ubuntu-latest
+    steps:
+      - uses: step-security/harden-runner@6c439dc8bdf85cadbbce9ed30d1c7b959517bc49 # v2.12.2
+        with: { egress-policy: audit }
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - run: |
+          gh release view $tag || \
+            gh release create ${tag/*-*/"$tag" --prerelease} --generate-notes
+        env:
+          GH_TOKEN: ${{ github.token }}
+          tag: ${{ github.ref_name }}
+
+  # Bump the 'vMajor' ref to latest patch|minor version
+  vMajor-ref:
+    if: ${{ !contains(github.ref, '-') }} # skip prereleases
+    permissions: { contents: write }
+    runs-on: ubuntu-latest
+    steps:
+      - uses: step-security/harden-runner@6c439dc8bdf85cadbbce9ed30d1c7b959517bc49 # v2.12.2
+        with: { egress-policy: audit }
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      # FIXME pushes branch instead of tag because github bug:
+      # https://github.com/orgs/community/discussions/163366
+      - run: git push -f origin "HEAD:refs/heads/${GITHUB_REF_NAME%%.*}"


### PR DESCRIPTION
This workflow contains two jobs that will each run on git-tag pushes, or
direct workflow dispatch (through the github UI).

The `github` job will create a GitHub Release for the triggering git
tag. If the tag name contains `-` (signifying prerelease per semver),
the release is marked as a prerelease. Release notes are generated
automatically using the gh-cli (handled by github). A future enhancement
would be to pull them from the Changelog.

The `vMajor-ref` job pushes a `vMajor` ref corresponding to the
triggering tag. For instance, if the latest tag is `v1.2.3`, and
`v1.2.4` or `v1.3.0` are pushed, then the branch `v1` is force-pushed to
point to the latest tag. This way these `vMajor` branches can be used by
users to pin to a "semver major" version rather than a minor or patch
release. (In actuality, this practice should probably be retired in
favor of using dependabot to bump and pin actions to explicit git-shas.)

This fixes #26 and #8
