### PR TITLE
Prepare v1.4.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 1.4.1
+
+* Fix typo in README by @garyhtou in https://github.com/standardrb/standard-ruby-action/pull/24
+* Create Release GHA workflow by @jasonkarns in https://github.com/standardrb/standard-ruby-action/pull/27
+* rename action for publishing to github marketplace by @jasonkarns in https://github.com/standardrb/standard-ruby-action/pull/28
+
 ## 1.4.0
 
 * Configurable working directory [#22](https://github.com/standardrb/standard-ruby-action/pull/22)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,18 +1,21 @@
 # How to release an update
 
-When cutting a new release, tag the versioned change and then move the current
-major version.
+1. Ensure the [changelog][] is current.
+2. Create a tag (signed, preferably) in the form "v1.2.3".
+3. Push the tag.
+4. Monitor the [release jobs][].
+    - The [release workflow][] creates a [GitHub Release][] for the pushed tag.
+    - The Release publishes the action to [GitHub Marketplace][].
+    - The release workflow also advances the corresponding [major version ref][].
 
-For example, right now I'm Releasing v1.1.0, so I'm going to:
-
-```sh
-git tag v1.1.0
+```console
+git tag -s v1.2.3
 git push --tags
 ```
 
-And then move the major tag:
-
-```
-git tag -fa v1 -m "Update v1 tag"
-git push origin v1 --force
-```
+[changelog]: ./CHANGELOG.md
+[release workflow]: .github/workflows/release.yml
+[github release]: https://github.com/standardrb/standard-ruby-action/releases
+[release jobs]: https://github.com/standardrb/standard-ruby-action/actions/workflows/release.yml
+[github marketplace]: https://github.com/marketplace/actions/standard-ruby-linter
+[major version ref]: https://github.com/standardrb/standard-ruby-action/branches/all?query=v


### PR DESCRIPTION
- Merge v1.4.0 tag into main (it wasn't in main's history).
- update release documentation
- update changelog