### PR TITLE
Pin action dependencies to full sha for security

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -20,7 +20,7 @@ runs:
   using: composite
 
   steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
 
     - name: Check for .ruby-version file
       id: use_ruby_version_or_default
@@ -35,7 +35,7 @@ runs:
           echo "No .ruby-version file found, using default"
         fi
 
-    - uses: ruby/setup-ruby@v1
+    - uses: ruby/setup-ruby@13e7a03dc3ac6c3798f4570bfead2aed4d96abfb # v1.244.0
       with:
         ruby-version: ${{ env.ruby-version || inputs.ruby-version }}
         bundler-cache: true

--- a/action.yml
+++ b/action.yml
@@ -20,8 +20,7 @@ runs:
   using: composite
 
   steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
+    - uses: actions/checkout@v4
 
     - name: Check for .ruby-version file
       id: use_ruby_version_or_default
@@ -36,14 +35,13 @@ runs:
           echo "No .ruby-version file found, using default"
         fi
 
-    - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
+    - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ env.ruby-version || inputs.ruby-version }}
         bundler-cache: true
         working-directory: ${{ inputs.workdir }}
 
-    - name: Run Standard Ruby with autofix
+    - name: Run Standard Ruby; optionally autofix
       id: standardrb
       shell: bash
       working-directory: ${{ inputs.workdir }}

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,7 @@
 name: Standard Ruby
 description: Lint and auto-fix your Ruby code with Standard Ruby.
 author: Justin Searls <searls@gmail.com>
+branding: { icon: code, color: yellow }
 
 inputs:
   ruby-version:
@@ -79,7 +80,3 @@ runs:
       run: |
         echo "::error::Standard Ruby found issues in your code."
         exit 1
-
-branding:
-  icon: code
-  color: yellow


### PR DESCRIPTION
- **Co-locate branding with metadata**
- **Remove redundant 'names'**
- **Pin actions to git shas for security**

Intentionally pinning to a slightly-older version of these actions so that we can observe dependabot bumping the versions immediately (and have confidence that we will continue to get dependency bump PRs)
