### PR TITLE
Don't pin production dependencies to SHAs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -40,7 +40,7 @@ runs:
           echo "ruby-version=ruby" >> "$GITHUB_ENV"
         fi
 
-    - uses: ruby/setup-ruby@7372622e62b60b3cb750dcd2b9e32c247ffec26a # v1.302.0
+    - uses: ruby/setup-ruby@v1 # unpinned to allow users to get latest rubies
       with:
         ruby-version: ${{ inputs.ruby-version || env.ruby-version }}
         bundler-cache: true


### PR DESCRIPTION
While sha-pinning is the most secure, this also limits consumers'
ability to have latest rubies available. (see #80)

We'll keep our devdeps pinned to shas, but relax our prod deps to major
versions. Leaving checkout action pinned because there shouldn't be any
reason that users need edge versions of the checkout action. (we'll
still need to keep it fresh with version bumps, but any lag in those
bumps is acceptable)

fixes #80 